### PR TITLE
wadler: break: use seprators instead of number of blank spaces

### DIFF
--- a/lib/oppen.rb
+++ b/lib/oppen.rb
@@ -95,12 +95,12 @@ module Oppen
     Token::String.new(value)
   end
 
-  # @param blank_space [Integer]
+  # @param str [String]
   # @param offset [Integer]
   #
   # @return [Oppen::Token::Break] a new Break token
-  def self.break(blank_space: 1, offset: 0)
-    Token::Break.new(blank_space:, offset:)
+  def self.break(str: ' ', offset: 0)
+    Token::Break.new(str:, offset:)
   end
 
   # @param offset [Integer]

--- a/lib/oppen.rb
+++ b/lib/oppen.rb
@@ -99,8 +99,8 @@ module Oppen
   # @param offset [Integer]
   #
   # @return [Oppen::Token::Break] a new Break token
-  def self.break(str: ' ', offset: 0)
-    Token::Break.new(str:, offset:)
+  def self.break(str = ' ', offset: 0)
+    Token::Break.new(str, offset:)
   end
 
   # @param offset [Integer]

--- a/lib/oppen/print_stack.rb
+++ b/lib/oppen/print_stack.rb
@@ -127,7 +127,7 @@ module Oppen
       case block.break_type
       in Token::BreakType::FITS
         @space -= token.length
-        write token.str
+        write token
       in Token::BreakType::CONSISTENT
         @space = block.offset - token.offset
         indent =
@@ -149,7 +149,7 @@ module Oppen
           print_new_line indent
         else
           @space -= token.length
-          write token.str
+          write token
         end
       end
     end
@@ -164,7 +164,7 @@ module Oppen
     # @see Token::String
     def handle_string(token, token_length)
       @space = [0, space - token_length].max
-      write token.value
+      write token
     end
 
     # Push a PrintStackEntry into the stack.
@@ -217,11 +217,11 @@ module Oppen
 
     # Write a string to the output.
     #
-    # @param string [String]
+    # @param obj [Object]
     #
     # @return [Nil]
-    def write(string)
-      buffer.write(string)
+    def write(obj)
+      buffer.write(obj.to_s)
     end
 
     # Add indentation by `amount`.

--- a/lib/oppen/print_stack.rb
+++ b/lib/oppen/print_stack.rb
@@ -126,8 +126,8 @@ module Oppen
       block = top
       case block.break_type
       in Token::BreakType::FITS
-        @space -= token.blank_space
-        indent token.blank_space
+        @space -= token.str.length
+        write token.str
       in Token::BreakType::CONSISTENT
         @space = block.offset - token.offset
         indent =
@@ -148,8 +148,8 @@ module Oppen
             end
           print_new_line indent
         else
-          @space -= token.blank_space
-          indent token.blank_space
+          @space -= token.str.length
+          write token.str
         end
       end
     end

--- a/lib/oppen/print_stack.rb
+++ b/lib/oppen/print_stack.rb
@@ -126,7 +126,7 @@ module Oppen
       block = top
       case block.break_type
       in Token::BreakType::FITS
-        @space -= token.str.length
+        @space -= token.length
         write token.str
       in Token::BreakType::CONSISTENT
         @space = block.offset - token.offset
@@ -148,7 +148,7 @@ module Oppen
             end
           print_new_line indent
         else
-          @space -= token.str.length
+          @space -= token.length
           write token.str
         end
       end

--- a/lib/oppen/printer.rb
+++ b/lib/oppen/printer.rb
@@ -166,7 +166,7 @@ module Oppen
       scan_stack.push right
       tokens[right] = token
       size[right] = -right_total
-      @right_total += token.str.length
+      @right_total += token.length
     end
 
     # Handle String Token.
@@ -228,7 +228,7 @@ module Oppen
 
       case token
       when Token::Break
-        @left_total += token.str.length
+        @left_total += token.length
       when Token::String
         @left_total += token_length
       end

--- a/lib/oppen/printer.rb
+++ b/lib/oppen/printer.rb
@@ -166,7 +166,7 @@ module Oppen
       scan_stack.push right
       tokens[right] = token
       size[right] = -right_total
-      @right_total += token.blank_space
+      @right_total += token.str.length
     end
 
     # Handle String Token.
@@ -228,7 +228,7 @@ module Oppen
 
       case token
       when Token::Break
-        @left_total += token.blank_space
+        @left_total += token.str.length
       when Token::String
         @left_total += token_length
       end

--- a/lib/oppen/token.rb
+++ b/lib/oppen/token.rb
@@ -38,6 +38,11 @@ module Oppen
       def length
         value.length
       end
+
+      # @return [String]
+      def to_s
+        value
+      end
     end
 
     # Break Token.
@@ -56,6 +61,11 @@ module Oppen
       # @return [Integer]
       def length
         str.length
+      end
+
+      # @return [String]
+      def to_s
+        str
       end
     end
 

--- a/lib/oppen/token.rb
+++ b/lib/oppen/token.rb
@@ -3,7 +3,7 @@
 # Oppen.
 module Oppen
   # Token.
-  module Token
+  class Token
     # BreakType.
     #
     # FITS => No break is needed (the block fits on the line).
@@ -18,13 +18,20 @@ module Oppen
       CONSISTENT = 2
     end
 
+    # Default token length
+    # @return [Integer]
+    def length
+      0
+    end
+
     # String Token.
-    class String
+    class String < Token
       # @return [String] String value.
       attr_reader :value
 
       def initialize(value)
         @value = value
+        super()
       end
 
       # @return [Integer]
@@ -34,7 +41,7 @@ module Oppen
     end
 
     # Break Token.
-    class Break
+    class Break < Token
       # @return [String] Break strings.
       attr_reader :str
       # @return [Integer] Indentation.
@@ -43,6 +50,12 @@ module Oppen
       def initialize(str: ' ', offset: 0)
         @str = str
         @offset = offset
+        super()
+      end
+
+      # @return [Integer]
+      def length
+        str.length
       end
     end
 
@@ -62,7 +75,7 @@ module Oppen
     end
 
     # Begin Token.
-    class Begin
+    class Begin < Token
       # @return [BreakType]
       attr_reader :break_type
       # @return [Integer] Indentation.
@@ -71,16 +84,17 @@ module Oppen
       def initialize(break_type: BreakType::INCONSISTENT, offset: 2)
         @offset = offset
         @break_type = break_type
+        super()
       end
     end
 
     # End Token
-    class End
+    class End < Token
       nil
     end
 
     # EOF Token
-    class EOF
+    class EOF < Token
       nil
     end
   end

--- a/lib/oppen/token.rb
+++ b/lib/oppen/token.rb
@@ -35,21 +35,29 @@ module Oppen
 
     # Break Token.
     class Break
-      # @return [Integer] Number of blank spaces.
-      attr_reader :blank_space
+      # @return [String] Break strings.
+      attr_reader :str
       # @return [Integer] Indentation.
       attr_reader :offset
 
-      def initialize(blank_space: 1, offset: 0)
-        @blank_space = blank_space
+      def initialize(str: ' ', offset: 0)
+        @str = str
         @offset = offset
       end
     end
 
     # Distinguished instance of Break which forces a line break.
     class LineBreak < Break
+      # Mock string that represents an infinite string to force new line.
+      class LineBreakString
+        # @return [Integer]
+        def length
+          999_999
+        end
+      end
+
       def initialize(offset: 0)
-        super(blank_space: 9999, offset:)
+        super(str: LineBreakString.new, offset:)
       end
     end
 

--- a/lib/oppen/token.rb
+++ b/lib/oppen/token.rb
@@ -47,7 +47,7 @@ module Oppen
       # @return [Integer] Indentation.
       attr_reader :offset
 
-      def initialize(str: ' ', offset: 0)
+      def initialize(str = ' ', offset: 0)
         @str = str
         @offset = offset
         super()
@@ -70,7 +70,7 @@ module Oppen
       end
 
       def initialize(offset: 0)
-        super(str: LineBreakString.new, offset:)
+        super(LineBreakString.new, offset:)
       end
     end
 

--- a/lib/wadler/print.rb
+++ b/lib/wadler/print.rb
@@ -83,11 +83,11 @@ module Oppen
       tokens << Oppen.string(value)
     end
 
-    # @param blank_space [Integer] number of blank spaces before next token
+    # @param str [String]
     #
     # @return [Nil]
-    def breakable(blank_space = 1)
-      tokens << Oppen.break(blank_space:, offset: current_indent)
+    def breakable(str = ' ')
+      tokens << Oppen.break(str:, offset: current_indent)
     end
 
     # @param offset [Integer] indentation of the break

--- a/lib/wadler/print.rb
+++ b/lib/wadler/print.rb
@@ -87,7 +87,7 @@ module Oppen
     #
     # @return [Nil]
     def breakable(str = ' ')
-      tokens << Oppen.break(str:, offset: current_indent)
+      tokens << Oppen.break(str, offset: current_indent)
     end
 
     # @param offset [Integer] indentation of the break

--- a/test/pretty_printer_test.rb
+++ b/test/pretty_printer_test.rb
@@ -187,11 +187,11 @@ describe 'Printer tests' do
     list = [
       Oppen::Token::Begin.new,
       Oppen::Token::String.new('hello'),
-      Oppen::Token::Break.new(blank_space: 0), Oppen::Token::String.new('.world'),
-      Oppen::Token::Break.new(blank_space: 0), Oppen::Token::String.new('.foo'),
-      Oppen::Token::Break.new(blank_space: 0), Oppen::Token::String.new('.bar'),
-      Oppen::Token::Break.new(blank_space: 0), Oppen::Token::String.new('.baz'),
-      Oppen::Token::Break.new(blank_space: 0), Oppen::Token::String.new('.42()'),
+      Oppen::Token::Break.new(str: ''), Oppen::Token::String.new('.world'),
+      Oppen::Token::Break.new(str: ''), Oppen::Token::String.new('.foo'),
+      Oppen::Token::Break.new(str: ''), Oppen::Token::String.new('.bar'),
+      Oppen::Token::Break.new(str: ''), Oppen::Token::String.new('.baz'),
+      Oppen::Token::Break.new(str: ''), Oppen::Token::String.new('.42()'),
       Oppen::Token::End.new,
       Oppen::Token::EOF.new
     ]

--- a/test/pretty_printer_test.rb
+++ b/test/pretty_printer_test.rb
@@ -187,11 +187,11 @@ describe 'Printer tests' do
     list = [
       Oppen::Token::Begin.new,
       Oppen::Token::String.new('hello'),
-      Oppen::Token::Break.new(str: ''), Oppen::Token::String.new('.world'),
-      Oppen::Token::Break.new(str: ''), Oppen::Token::String.new('.foo'),
-      Oppen::Token::Break.new(str: ''), Oppen::Token::String.new('.bar'),
-      Oppen::Token::Break.new(str: ''), Oppen::Token::String.new('.baz'),
-      Oppen::Token::Break.new(str: ''), Oppen::Token::String.new('.42()'),
+      Oppen::Token::Break.new(''), Oppen::Token::String.new('.world'),
+      Oppen::Token::Break.new(''), Oppen::Token::String.new('.foo'),
+      Oppen::Token::Break.new(''), Oppen::Token::String.new('.bar'),
+      Oppen::Token::Break.new(''), Oppen::Token::String.new('.baz'),
+      Oppen::Token::Break.new(''), Oppen::Token::String.new('.42()'),
       Oppen::Token::End.new,
       Oppen::Token::EOF.new
     ]


### PR DESCRIPTION
fixes: https://github.com/Faveod/oppen-ruby/issues/18