### PR TITLE
oppen: use tokens length when calling modulo on left and right

### DIFF
--- a/lib/oppen/printer.rb
+++ b/lib/oppen/printer.rb
@@ -265,16 +265,16 @@ module Oppen
       trim_on_break =
         if token.is_a?(Token::Break)
           # Find the first previous String token.
-          idx = (left - 1) % scan_stack.length
+          idx = (left - 1) % tokens.length
           while idx != right && tokens[idx] && !tokens[idx].is_a?(Token::String) \
                 && !tokens[idx].is_a?(Token::Break)
-            idx = (idx - 1) % scan_stack.length
+            idx = (idx - 1) % tokens.length
           end
           # Sum the widths of the last whitespace tokens.
           total = 0
           while tokens[idx].is_a?(Token::Whitespace)
             total += tokens[idx].width
-            idx = (idx - 1) % scan_stack.length
+            idx = (idx - 1) % tokens.length
           end
           @last_whitespaces_width = 0
           total
@@ -292,7 +292,7 @@ module Oppen
 
       return if left == right
 
-      @left = (left + 1) % scan_stack.length
+      @left = (left + 1) % tokens.length
       advance_left tokens[left], size[left]
     end
 

--- a/test/wadler_test.rb
+++ b/test/wadler_test.rb
@@ -533,6 +533,18 @@ describe 'Wadler tests' do
          16
       LANG
     end
+
+    it 'must work with a big token list that doesn\'t overflow the scan stack' do
+      wadler = Oppen::Wadler.new(width: 2)
+      wadler.group {
+        wadler.group {
+          wadler.group {
+            wadler.text 'a'
+          }
+        }
+      }
+      _(wadler.output).must_equal 'a'
+    end
   end
 
   describe 'must work with width different from length' do


### PR DESCRIPTION
The was a time when using the scan_stack length was the right thing to do since we were always upsizing all our arrays at the same time. However, in the current version it breaks if the scan stack does not need upsizing and the tokens and size lists need upsizing.