### PR TITLE
break_types: convert enum to symbols

### DIFF
--- a/examples/configs/indent_anchor.rb
+++ b/examples/configs/indent_anchor.rb
@@ -4,12 +4,12 @@ require_relative '../helper'
 
 printer_with_config =
   Oppen::Wadler.new(
-    config: Oppen::Config.new(indent_anchor: Oppen::Config::IndentAnchor::CURRENT_OFFSET),
+    config: Oppen::Config.new(indent_anchor: :current_offset),
     width: 13,
   )
 printer_no_config =
   Oppen::Wadler.new(
-    config: Oppen::Config.new(indent_anchor: Oppen::Config::IndentAnchor::END_OF_PREVIOUS_LINE),
+    config: Oppen::Config.new(indent_anchor: :end_of_previous_line),
     width: 13,
   )
 test_block = ->(printer) {
@@ -24,14 +24,14 @@ test_block = ->(printer) {
 test_block.(printer_with_config)
 test_block.(printer_no_config)
 
-title 'CURRENT_OFFSET:'
+title ':current_offset:'
 puts printer_with_config.output
 # And she said:
 #         Hello, World!
 
 puts ''
 
-title 'END_OF_PREVIOUS_LINE:'
+title ':end_of_previous_line:'
 puts printer_no_config.output
 # And she said:
 #                  Hello, World!

--- a/examples/show_print_commands/show_print_commands.rb
+++ b/examples/show_print_commands/show_print_commands.rb
@@ -13,7 +13,7 @@ printer.group(2) {
 }
 
 puts printer.show_print_commands
-# out.group(2, "", "", Oppen::Token::BreakType::CONSISTENT) {
+# out.group(2, "", "", :consistent) {
 #   out.text("Hello, World!", width: 13)
 #   out.nest(4, "", "") {
 #     out.break(line_continuation: "")

--- a/examples/wadler_break_and_breakable/breakable.rb
+++ b/examples/wadler_break_and_breakable/breakable.rb
@@ -7,8 +7,8 @@ require_relative '../helper'
 
 printer = Oppen::Wadler.new(width: 40)
 
-# See `examples/wadler_group/inconsistent.rb` for more infos about `Oppen::Token::BreakType::INCONSISTENT`
-printer.group(0, '', '', Oppen::Token::BreakType::INCONSISTENT) {
+# See `examples/wadler_group/inconsistent.rb` for more infos about `:inconsistent`
+printer.group(0, '', '', :inconsistent) {
   printer.text 'Hello, World!'
   printer.breakable
   printer.text '(still fits on the line)'

--- a/examples/wadler_group/inconsistent.rb
+++ b/examples/wadler_group/inconsistent.rb
@@ -7,7 +7,7 @@ require_relative '../helper'
 
 printer = Oppen::Wadler.new(width: 999_999)
 
-printer.group(0, '', '', Oppen::Token::BreakType::INCONSISTENT) {
+printer.group(0, '', '', :inconsistent) {
   printer.text 'Hello, World!'
   printer.breakable
   printer.text 'How are you doing?'

--- a/lib/oppen/mixins.rb
+++ b/lib/oppen/mixins.rb
@@ -35,7 +35,7 @@ module Oppen
     #   out.show_print_commands(out_name: 'out')
     #
     #   # =>
-    #   # out.group(0, "", "", Oppen::Token::BreakType::CONSISTENT) {
+    #   # out.group(0, "", "", :consistent) {
     #   #   out.text("Hello World!", width: 12)
     #   # }
     #
@@ -76,7 +76,7 @@ module Oppen
         in Token::Break
           handle_break_token.(token)
         in Token::Begin
-          printer.text "#{printer_name}.group(#{token.offset}, '', '', #{token.break_type_name}) {"
+          printer.text "#{printer_name}.group(#{token.offset}, '', '', #{token.break_type.inspect}) {"
           printer.nest_open indent
         in Token::End
           printer.nest_close indent

--- a/lib/oppen/print_stack.rb
+++ b/lib/oppen/print_stack.rb
@@ -94,12 +94,12 @@ module Oppen
     def handle_begin(token, token_width)
       if token_width > space
         type =
-          if token.break_type == Token::BreakType::CONSISTENT
-            Token::BreakType::CONSISTENT
+          if token.break_type == :consistent
+            :consistent
           else
-            Token::BreakType::INCONSISTENT
+            :inconsistent
           end
-        if config&.indent_anchor == Config::IndentAnchor::CURRENT_OFFSET
+        if config&.indent_anchor == :current_offset
           indent = token.offset
           if !items.empty?
             indent += top.offset
@@ -109,7 +109,7 @@ module Oppen
         end
         push PrintStackEntry.new indent, type
       else
-        push PrintStackEntry.new 0, Token::BreakType::FITS
+        push PrintStackEntry.new 0, :fits
       end
     end
 
@@ -135,13 +135,14 @@ module Oppen
     def handle_break(token, token_width, trim_on_break: 0)
       block = top
       case block.break_type
-      in Token::BreakType::FITS
+      in :fits
+        # No new line is needed (the block fits on the line).
         @space -= token.width
         write token
-      in Token::BreakType::CONSISTENT
+      in :consistent
         @space = block.offset - token.offset
         indent =
-          if config&.indent_anchor == Config::IndentAnchor::CURRENT_OFFSET
+          if config&.indent_anchor == :current_offset
             token.offset
           else
             width - space
@@ -149,11 +150,11 @@ module Oppen
         erase trim_on_break
         write token.line_continuation
         print_new_line indent
-      in Token::BreakType::INCONSISTENT
+      in :inconsistent
         if token_width > space
           @space = block.offset - token.offset
           indent =
-            if config&.indent_anchor == Config::IndentAnchor::CURRENT_OFFSET
+            if config&.indent_anchor == :current_offset
               token.offset
             else
               width - space
@@ -227,7 +228,7 @@ module Oppen
     # @return [Nil]
     def print_new_line(amount)
       write new_line
-      if config&.indent_anchor == Config::IndentAnchor::CURRENT_OFFSET
+      if config&.indent_anchor == :current_offset
         @space = width - top.offset - amount
         @indent = width - space
       else

--- a/lib/oppen/token.rb
+++ b/lib/oppen/token.rb
@@ -4,58 +4,6 @@
 module Oppen
   # Token.
   class Token
-    # BreakType.
-    # @example inconsistent
-    #   out = Oppen::Wadler.new
-    #   out.group(0, '', '', Oppen::Token::BreakType::INCONSISTENT) {
-    #     out.text 'a'
-    #     out.break
-    #     out.text 'b'
-    #     out.breakable
-    #     out.text 'c'
-    #   }
-    #   out.output
-    #
-    #   # =>
-    #   # a
-    #   # b c
-    #
-    # @example consistent
-    #   out = Oppen::Wadler.new
-    #   out.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
-    #     out.text 'a'
-    #     out.break
-    #     out.text 'b'
-    #     out.breakable
-    #     out.text 'c'
-    #   }
-    #   out.output
-    #
-    #   # =>
-    #   # a
-    #   # b
-    #   # c
-    module BreakType
-      # No new line is needed (the block fits on the line).
-      # The Break tokens will only output their `str` field.
-      # Not for public use.
-      #
-      # @return [Integer]
-      FITS = 0
-      # The presence of a new line inside the group will not propagate
-      # to the other Break tokens in the group letting them decide
-      # if they need to act as a new line or not.
-      #
-      # @return [Integer]
-      INCONSISTENT = 1
-      # The presence of a new line inside the group will propagate
-      # to the other Break tokens in the group
-      # causing them all to act as a new line.
-      #
-      # @return [Integer]
-      CONSISTENT = 2
-    end
-
     # Default token width.
     #
     # @return [Integer]
@@ -137,21 +85,10 @@ module Oppen
       # @return [Integer] Indentation.
       attr_reader :offset
 
-      def initialize(break_type: BreakType::INCONSISTENT, offset: 2)
+      def initialize(break_type: :inconsistent, offset: 2)
         @offset = offset
         @break_type = break_type
         super()
-      end
-
-      # The break_type name as a String.
-      #
-      # @return [String]
-      def break_type_name
-        case @break_type
-        in BreakType::FITS         then 'Oppen::Token::BreakType::FITS'
-        in BreakType::INCONSISTENT then 'Oppen::Token::BreakType::INCONSISTENT'
-        in BreakType::CONSISTENT   then 'Oppen::Token::BreakType::CONSISTENT'
-        end
       end
     end
 

--- a/lib/wadler/print.rb
+++ b/lib/wadler/print.rb
@@ -99,19 +99,51 @@ module Oppen
     #   #   b
     #   #   }
     #
+    # @example consistent
+    #   out = Oppen::Wadler.new
+    #   out.group(0, '', '', :consistent) {
+    #     out.text 'a'
+    #     out.break
+    #     out.text 'b'
+    #     out.breakable
+    #     out.text 'c'
+    #   }
+    #   out.output
+    #
+    #   # =>
+    #   # a
+    #   # b
+    #   # c
+    #
+    # @example inconsistent
+    #   out = Oppen::Wadler.new
+    #   out.group(0, '', '', :inconsistent) {
+    #     out.text 'a'
+    #     out.break
+    #     out.text 'b'
+    #     out.breakable
+    #     out.text 'c'
+    #   }
+    #   out.output
+    #
+    #   # =>
+    #   # a
+    #   # b c
+    #
     # @return [Nil]
     #
-    # @see Token::BreakType
+    # @see Oppen.begin_consistent
+    # @see Oppen.begin_inconsistent
     def group(indent = 0, open_obj = '', close_obj = '',
-              break_type = Oppen::Token::BreakType::CONSISTENT)
+              break_type = :consistent)
       raise ArgumentError, "#{open_obj.nil? ? 'open_obj' : 'close_obj'} cannot be nil" \
         if open_obj.nil? || close_obj.nil?
 
       tokens <<
         case break_type
-        in Oppen::Token::BreakType::CONSISTENT
+        in :consistent
           Oppen.begin_consistent(offset: indent)
-        in Oppen::Token::BreakType::INCONSISTENT
+        in :inconsistent
           Oppen.begin_inconsistent(offset: indent)
         end
 
@@ -249,7 +281,8 @@ module Oppen
     #
     # @return [Nil]
     #
-    # @see Token::BreakType
+    # @see Oppen.begin_consistent
+    # @see Oppen.begin_inconsistent
     def group_open(inconsistent: false, indent: 0)
       tokens <<
         if inconsistent

--- a/test/customization_test.rb
+++ b/test/customization_test.rb
@@ -7,7 +7,7 @@ def customization_build_output(printer)
     printer.text 'function'
     printer.breakable
     printer.text 'test('
-    printer.group(2, '', '', Oppen::Token::BreakType::INCONSISTENT) {
+    printer.group(2, '', '', :inconsistent) {
       printer.break
       printer.text 'int index,'
       printer.breakable
@@ -29,7 +29,7 @@ describe 'Inconsistent break tests' do
       printer.text 'function'
       printer.breakable
       printer.text 'test('
-      printer.group(2, '', '', Oppen::Token::BreakType::INCONSISTENT) {
+      printer.group(2, '', '', :inconsistent) {
         printer.breakable
         printer.text 'int index,'
         printer.breakable
@@ -398,7 +398,7 @@ describe 'Group delimiter tests' do
 end
 
 describe 'Line continuation tests' do
-  def line_continuation_build_output(printer, break_type = Oppen::Token::BreakType::CONSISTENT,
+  def line_continuation_build_output(printer, break_type = :consistent,
                                      line_continuation = ',')
     printer.group(0) {
       printer.text('[')
@@ -436,7 +436,7 @@ describe 'Line continuation tests' do
 
   it 'must display line continuation if line does not fit (INCONSISTENT break)' do
     printer = Oppen::Wadler.new(width: 7)
-    line_continuation_build_output(printer, Oppen::Token::BreakType::INCONSISTENT)
+    line_continuation_build_output(printer, :inconsistent)
     _(printer.output).must_equal <<~LANG.chomp
       [1, 2,
         3,
@@ -446,7 +446,7 @@ describe 'Line continuation tests' do
 
   it 'must work with UTF-8 string' do
     printer = Oppen::Wadler.new(width: 3)
-    line_continuation_build_output(printer, Oppen::Token::BreakType::CONSISTENT, 'Ѿ')
+    line_continuation_build_output(printer, :consistent, 'Ѿ')
     _(printer.output).must_equal <<~LANG.chomp
       [
         1Ѿ
@@ -458,6 +458,6 @@ describe 'Line continuation tests' do
 
   it 'must raise an error when line_continuation is nil' do
     printer = Oppen::Wadler.new(width: 3)
-    _ { line_continuation_build_output(printer, Oppen::Token::BreakType::CONSISTENT, nil) }.must_raise ArgumentError
+    _ { line_continuation_build_output(printer, :consistent, nil) }.must_raise ArgumentError
   end
 end

--- a/test/pretty_printer_test.rb
+++ b/test/pretty_printer_test.rb
@@ -131,7 +131,7 @@ describe 'Printer tests' do
           end;
       LANG
 
-    list[0] = Oppen::Token::Begin.new break_type: Oppen::Token::BreakType::CONSISTENT
+    list[0] = Oppen::Token::Begin.new break_type: :consistent
 
     _(Oppen.print(tokens: list))
       .must_equal <<~LANG.chomp
@@ -146,7 +146,7 @@ describe 'Printer tests' do
 
   it 'must work with nested blocks' do
     list = [
-      Oppen::Token::Begin.new(break_type: Oppen::Token::BreakType::CONSISTENT),
+      Oppen::Token::Begin.new(break_type: :consistent),
 
       Oppen::Token::String.new('procedure test(x, y: Integer);'), Oppen::Token::LineBreak.new,
       Oppen::Token::String.new('begin'),
@@ -154,7 +154,7 @@ describe 'Printer tests' do
       Oppen::Token::LineBreak.new(offset: 2), Oppen::Token::String.new('x:=1;'),
       Oppen::Token::LineBreak.new(offset: 2), Oppen::Token::String.new('y:=200;'),
 
-      Oppen::Token::LineBreak.new(offset: 2), Oppen::Token::Begin.new(break_type: Oppen::Token::BreakType::CONSISTENT),
+      Oppen::Token::LineBreak.new(offset: 2), Oppen::Token::Begin.new(break_type: :consistent),
       Oppen::Token::String.new('for z:= 1 to 100 do'), Oppen::Token::LineBreak.new,
       Oppen::Token::String.new('begin'),
       Oppen::Token::LineBreak.new(offset: 2), Oppen::Token::String.new('x := x + z;'), Oppen::Token::LineBreak.new,
@@ -202,7 +202,7 @@ describe 'Printer tests' do
           .baz.42()
       LANG
 
-    list[0] = Oppen::Token::Begin.new(break_type: Oppen::Token::BreakType::CONSISTENT)
+    list[0] = Oppen::Token::Begin.new(break_type: :consistent)
 
     _(Oppen.print(tokens: list, width: 20))
       .must_equal <<~LANG.chomp

--- a/test/token_to_wadler_test.rb
+++ b/test/token_to_wadler_test.rb
@@ -10,7 +10,7 @@ describe 'Token to wadler tests' do
         printer
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
         }
 
       LANG
@@ -21,7 +21,7 @@ describe 'Token to wadler tests' do
         printer.text('Hello World!')
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.text("Hello World!", width: 12)
         }
 
@@ -33,7 +33,7 @@ describe 'Token to wadler tests' do
         printer.text('"\'Hello World!\'"')
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.text("\\"'Hello World!'\\"", width: 16)
         }
 
@@ -45,7 +45,7 @@ describe 'Token to wadler tests' do
         printer.text('Ḽơᶉëᶆ ȋṕšᶙṁ ḍỡḽǭᵳ')
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.text("Ḽơᶉëᶆ ȋṕšᶙṁ ḍỡḽǭᵳ", width: 17)
         }
 
@@ -57,7 +57,7 @@ describe 'Token to wadler tests' do
         printer.text('Hello World!', width: 42)
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.text("Hello World!", width: 42)
         }
 
@@ -69,7 +69,7 @@ describe 'Token to wadler tests' do
         printer.text('Hello World!  ')
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.text("Hello World!", width: 12)
           printer.text("  ", width: 2)
         }
@@ -80,7 +80,7 @@ describe 'Token to wadler tests' do
       title: 'displays a simple break token',
       block: proc(&:break),
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.break(line_continuation: "")
         }
 
@@ -92,7 +92,7 @@ describe 'Token to wadler tests' do
         printer.break(line_continuation: '##')
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.break(line_continuation: "##")
         }
 
@@ -102,7 +102,7 @@ describe 'Token to wadler tests' do
       title: 'displays a simple breakable token',
       block: proc(&:breakable),
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.breakable(" ", width: 1, line_continuation: "")
         }
 
@@ -114,7 +114,7 @@ describe 'Token to wadler tests' do
         printer.breakable('**', width: 42, line_continuation: '##')
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.breakable("**", width: 42, line_continuation: "##")
         }
 
@@ -128,7 +128,7 @@ describe 'Token to wadler tests' do
         }
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.text("Hello World!", width: 12)
         }
 
@@ -137,12 +137,12 @@ describe 'Token to wadler tests' do
     {
       title: 'displays a group token with arguments',
       block: proc { |printer|
-        printer.group(2, '{', '}', Oppen::Token::BreakType::INCONSISTENT) {
+        printer.group(2, '{', '}', :inconsistent) {
           printer.text('Hello World!')
         }
       },
       expected: <<~LANG,
-        printer.group(2, '', '', Oppen::Token::BreakType::INCONSISTENT) {
+        printer.group(2, '', '', :inconsistent) {
           printer.break(line_continuation: "")
           printer.text("{", width: 1)
           printer.text("Hello World!", width: 12)
@@ -166,7 +166,7 @@ describe 'Token to wadler tests' do
         printer.text('Hello World!')
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.text("Hello World!", width: 12)
           printer.break(line_continuation: "")
           printer.breakable(" ", width: 1, line_continuation: "")
@@ -196,11 +196,11 @@ describe 'Token to wadler tests' do
         }
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
-          printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
-            printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
-              printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
-                printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
+          printer.group(0, '', '', :consistent) {
+            printer.group(0, '', '', :consistent) {
+              printer.group(0, '', '', :consistent) {
+                printer.group(0, '', '', :consistent) {
                   printer.text("Hello World!", width: 12)
                 }
               }
@@ -220,7 +220,7 @@ describe 'Token to wadler tests' do
         }
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.nest(2, '', '') {
             printer.breakable(" ", width: 1, line_continuation: "")
           }
@@ -242,7 +242,7 @@ describe 'Token to wadler tests' do
         }
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.text("{", width: 1)
           printer.nest(2, '', '') {
             printer.break(line_continuation: "")
@@ -274,7 +274,7 @@ describe 'Token to wadler tests' do
         }
       },
       expected: <<~LANG,
-        printer.group(0, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(0, '', '', :consistent) {
           printer.nest(6, '', '') {
             printer.breakable(" ", width: 1, line_continuation: "")
           }
@@ -302,8 +302,8 @@ describe 'Token to wadler tests' do
         }
       },
       expected: <<~LANG,
-        printer.group(2, '', '', Oppen::Token::BreakType::CONSISTENT) {
-          printer.group(2, '', '', Oppen::Token::BreakType::CONSISTENT) {
+        printer.group(2, '', '', :consistent) {
+          printer.group(2, '', '', :consistent) {
             printer.nest(4, '', '') {
               printer.breakable(" ", width: 1, line_continuation: "")
             }


### PR DESCRIPTION
Fixes https://github.com/Faveod/oppen-ruby/issues/19