### PR TITLE
wadler: trim trailing whitespaces of line_continuation when enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+- Trim trailing whitespaces of line_continuation when enabled.
+
 ## v1.0.0 (21-01-2025)
 
 - Drop support for Ruby < 3.1.

--- a/lib/wadler/print.rb
+++ b/lib/wadler/print.rb
@@ -345,6 +345,9 @@ module Oppen
     #
     # @see Wadler#break example on `line_continuation`.
     def breakable(str = ' ', line_continuation: '', width: str.length)
+      if config.trim_trailing_whitespaces? && line_continuation
+        line_continuation = line_continuation.sub(/(?:#{Regexp.escape(whitespace)})+\z/, '')
+      end
       tokens << Oppen.break(str, width:, line_continuation:, offset: current_indent)
       self
     end
@@ -370,6 +373,9 @@ module Oppen
     #
     # @return [self]
     def break(line_continuation: '')
+      if line_continuation && config.trim_trailing_whitespaces?
+        line_continuation = line_continuation.sub(/(?:#{Regexp.escape(whitespace)})+\z/, '')
+      end
       tokens << Oppen.line_break(line_continuation:, offset: current_indent)
       self
     end

--- a/test/trim_trailing_whitespaces_test.rb
+++ b/test/trim_trailing_whitespaces_test.rb
@@ -189,6 +189,20 @@ describe 'Trim trailing whitespaces tests' do
         },
         expected: "#{whitespace}a\n\n#{whitespace}a\n\n",
       },
+      {
+        title: "trims `#{whitespace}` from line_continuation",
+        block: proc { |printer|
+          printer.text('Hello World!')
+          printer.break(line_continuation: "#{whitespace}^_^#{whitespace}")
+          printer.text('How are you doing?')
+          printer.breakable(line_continuation: "#{whitespace}^_^#{whitespace}")
+        },
+        expected: <<~LANG.chomp,
+          Hello World!#{whitespace}^_^
+          How are you doing?#{whitespace}^_^
+
+        LANG
+      },
     ].each do |test|
       it test[:title] do
         printer = Oppen::Wadler.new(width: 5, whitespace:)


### PR DESCRIPTION
Fixes #60.